### PR TITLE
Update nightly workflow to include path filters

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,20 +3,28 @@
 name: Build and upload nightly
 
 on:
- push:
-   branches:
-     - main
+  push:
+    branches:
+      - main
+    paths:
+      - 'Shirox/**'
+      - 'Shirox.xcodeproj/**'
+      - 'ShiroxTests/**'
+      # Optional:
+      - 'Configurations/**'
+      - 'buildipa.sh'
+      - 'buildcatalyst.sh'
 
 env:
- FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
- build-ios:
-   name: Build iOS IPA
-   runs-on: macos-26
-   permissions:
-     contents: write
-   steps:
+  build-ios:
+    name: Build iOS IPA
+    runs-on: macos-26
+    permissions:
+      contents: write
+    steps:
      - name: Checkout repository
        uses: actions/checkout@v6
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,7 @@ on:
       - 'Configurations/**'
       - 'buildipa.sh'
       - 'buildcatalyst.sh'
+      - 'builddmg.sh'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Added path filters to the nightly workflow for specific directories and files.

this is so it doesn’t trigger a full build when you just change the readme. It also helps on saving a bit on the monthly gh action limit this way